### PR TITLE
Framework to manage EFS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,13 +3,17 @@ module openshift/aws-efs-operator
 go 1.13
 
 require (
+	github.com/aws/aws-sdk-go v1.31.4
+	github.com/go-bindata/go-bindata v3.1.2+incompatible // indirect
 	github.com/go-logr/logr v0.1.0
 	github.com/golang/mock v1.4.3
 	github.com/google/go-cmp v0.3.1
 	github.com/openshift/api v3.9.1-0.20190924102528-32369d4db2ad+incompatible
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/spf13/pflag v1.0.5
-	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
+	golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2
+	golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375 // indirect
+	google.golang.org/appengine v1.6.6 // indirect
 	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -69,7 +69,10 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
 github.com/aws/aws-sdk-go v1.16.26/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.17.7 h1:/4+rDPe0W95KBmNGYCG+NUvdL8ssPYBMxL+aSCg6nIA=
 github.com/aws/aws-sdk-go v1.17.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.31.4 h1:YZ0uEYIWeanGuAomElHmRWMAbXVqrQixxgf2vtIjO6M=
+github.com/aws/aws-sdk-go v1.31.4/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/bazelbuild/bazel-gazelle v0.0.0-20181012220611-c728ce9f663e/go.mod h1:uHBSeeATKpVazAACZBDPL/Nk/UhQDDsJWDlqYJo8/Us=
 github.com/bazelbuild/buildtools v0.0.0-20180226164855-80c7f0d45d7e/go.mod h1:5JP0TXzWDHXv8qvxRC4InIazwdyDseBDbzESUMKk1yU=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -209,6 +212,7 @@ github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8/go.mod h1:xkRDCp4j0
 github.com/go-acme/lego v2.5.0+incompatible/go.mod h1:yzMNe9CasVUhkquNvti5nAtPmG94USbYxYrZfTkIn0M=
 github.com/go-bindata/go-bindata v3.1.1+incompatible h1:tR4f0e4VTO7LK6B2YWyAoVEzG9ByG1wrXB4TL9+jiYg=
 github.com/go-bindata/go-bindata v3.1.1+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
+github.com/go-bindata/go-bindata v3.1.2+incompatible/go.mod h1:xK8Dsgwmeed+BBsSy2XTopBn/8uK2HWuGSnA11C3Joo=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
@@ -263,7 +267,10 @@ github.com/go-openapi/validate v0.18.0/go.mod h1:Uh4HdOzKt19xGIGm1qHf/ofbX1YQ4Y+
 github.com/go-openapi/validate v0.19.2/go.mod h1:1tRCw7m3jtI8eNWEEliiAqUIcBztB2KDnRCRMUi7GTA=
 github.com/go-ozzo/ozzo-validation v3.5.0+incompatible/go.mod h1:gsEKFIVnabGBt6mXmxK0MoFy+cZoTJY6mu5Ll3LVLBU=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gobuffalo/envy v1.6.5/go.mod h1:N+GkhhZ/93bGZc6ZKhJLP6+m+tCNPKwgSpH9kaifseQ=
 github.com/gobuffalo/envy v1.7.0/go.mod h1:n7DRkBerg/aorDM8kbduw5dN3oXGswK5liaSCx4T5NI=
@@ -390,7 +397,10 @@ github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANyt
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joefitzgerald/rainbow-reporter v0.1.0/go.mod h1:481CNgqmVHQZzdIbN52CupLJyoVwB10FQ/IQlF1pdL8=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
@@ -543,6 +553,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v0.0.0-20151028094244-d8ed2627bdf0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -633,6 +645,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/syndtr/gocapability v0.0.0-20160928074757-e7cb7fa329f4/go.mod h1:hkRG7XYTFWNJGYcbNJQlaLq0fg1yr4J4t/NcTQtrfww=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=
 github.com/tidwall/pretty v0.0.0-20180105212114-65a9db5fad51/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
@@ -656,6 +670,7 @@ github.com/xiang90/probing v0.0.0-20160813154853-07dd2e8dfe18/go.mod h1:UETIi67q
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/handysort v0.0.0-20150421192137-fb3537ed64a1/go.mod h1:QcJo0QPSfTONNIgpN5RA8prR7fF8nkF6cTWTcNerRO8=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
+github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yvasiyarov/go-metrics v0.0.0-20150112132944-c25f46c4b940/go.mod h1:aX5oPXxHm3bOH+xeAttToC8pqch2ScQN/JoXYupl6xs=
 github.com/yvasiyarov/gorelic v0.0.6/go.mod h1:NUSPSUX/bi6SeDMUh6brw0nXpxHnc96TguQh0+r/ssA=
 github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go.mod h1:GlGEuHIJweS1mbCqG+7vt2nvWLzLLnRHbXz5JKd/Qbg=
@@ -690,6 +705,7 @@ golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152 h1:ZC1Xn5A1nlpSmQCIva4bZ3ob3lmhYIefc+GU+DLg1Ow=
 golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -704,6 +720,7 @@ golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHl
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180112015858-5ccada7d0a7b/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -734,6 +751,10 @@ golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc/go.mod h1:mL1N/T3taQHkDXs73r
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271 h1:N66aaryRB3Ax92gH0v3hp1QYZ3zWWCCUR/j8Ifh45Ss=
 golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
+golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -776,6 +797,8 @@ golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934 h1:u/E0NqCIWRDAo9WCFo6Ko49njPFDLSd3z+X1HgWDMpE=
 golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -810,8 +833,13 @@ golang.org/x/tools v0.0.0-20190624180213-70d37148ca0c/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190706070813-72ffa07ba3db/go.mod h1:jcCCGcm9btYwXyDqrUWc6MKQKKGJCWEQ3AfLSRIbEuI=
 golang.org/x/tools v0.0.0-20191018212557-ed542cd5b28a h1:UuQ+70Pi/ZdWHuP4v457pkXeOynTdgd/4enxeIO/98k=
 golang.org/x/tools v0.0.0-20191018212557-ed542cd5b28a/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200522201501-cb1345f3a375/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gomodules.xyz/jsonpatch/v2 v2.0.1 h1:xyiBuvkD2g5n7cYzx6u2sxQvsAy4QJsZFCzGVdzOXZ0=
 gomodules.xyz/jsonpatch/v2 v2.0.1/go.mod h1:IhYNNY4jnS53ZnfE4PAmpKtDpTCj1JFXc+3mwe7XcUU=
 gonum.org/v1/gonum v0.0.0-20190331200053-3d26580ed485/go.mod h1:2ltnJ7xHfj0zHS40VVPYEAAMTa3ZGguvHGBSJeRWqE0=
@@ -828,6 +856,7 @@ google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190128161407-8ac453e89fca/go.mod h1:L3J43x8/uS+qIUoksaLKe6OS3nUKxOKuIFz1sl2/jx4=
 google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19/go.mod h1:VzzqZJRnGkLBvHegQrXjBqPurQTc5/KpmUdxsrq26oE=

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -1,0 +1,367 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/efs"
+)
+
+const (
+	fsTokenMarker = "managed.openshift.io/aws-efs-operator-fs"
+	apTokenMarker = "managed.openshift.io/aws-efs-operator-ap"
+)
+
+// TODO(efried): real log setup
+type logstub struct{}
+
+func (l *logstub) Info(msg string, args ...interface{}) {
+	fmt.Println(msg)
+	for i := 0; i < len(args); i += 2 {
+		fmt.Printf("\t%s: %s\n", args[i], args[i+1])
+	}
+}
+
+var log = logstub{}
+
+// accessPoint is a map of an access point "key" (arbitrary user-specified name) to its AccessPointId.
+type accessPoints map[string]string
+
+type fileSystem struct {
+	fileSystemID       string
+	lastLifeCycleState string
+	accessPoints       accessPoints
+}
+
+// fileSystems is a map of a file system "key" (arbitrary user-specified name) to a fileSystem struct
+// which contains its FSID and access points.
+type fileSystems map[string]fileSystem
+
+func getSession() *session.Session {
+	return session.Must(session.NewSessionWithOptions(
+		session.Options{
+			SharedConfigState: session.SharedConfigEnable}))
+}
+
+func getEC2(sess *session.Session) *ec2.EC2 {
+	return ec2.New(sess)
+}
+
+func getEFS(sess *session.Session) *efs.EFS {
+	return efs.New(sess)
+}
+
+func getWorkers(ec2svc *ec2.EC2) []*ec2.Instance {
+	filt := &ec2.DescribeInstancesInput{
+		Filters: []*ec2.Filter{
+			{
+				// TODO(efried): Is this the right filter?
+				Name:   aws.String("iam-instance-profile.arn"),
+				Values: []*string{aws.String("*-worker-*")},
+			},
+		},
+	}
+	res, err := ec2svc.DescribeInstances(filt)
+	if err != nil {
+		panic(err)
+	}
+	ret := make([]*ec2.Instance, 0)
+	for _, reservation := range res.Reservations {
+		for _, inst := range reservation.Instances {
+			ret = append(ret, inst)
+		}
+	}
+	if len(ret) == 0 {
+		panic("Couldn't find any workers.")
+	}
+	return ret
+}
+
+func getSecurityGroupID(workers []*ec2.Instance) string {
+	// The security group ought to be the same for any worker, so just pick the first one
+	return *workers[0].SecurityGroups[0].GroupId
+}
+
+func getSubnetIDs(workers []*ec2.Instance) []*string {
+	ret := make([]*string, 0)
+	for _, inst := range workers {
+		ret = append(ret, inst.NetworkInterfaces[0].SubnetId)
+	}
+	if len(ret) == 0 {
+		panic("No subnets found.")
+	}
+	return ret
+}
+
+func getOwnedTag(workers []*ec2.Instance) *ec2.Tag {
+	// The owned tag should be the same for any instance, so just pick the first one
+	for _, tag := range workers[0].Tags {
+		if *tag.Value == "owned" {
+			return tag
+		}
+	}
+	panic("Couldn't find an 'owned' tag.")
+}
+
+func tagEC2ToEFS(ec2Tag *ec2.Tag) *efs.Tag {
+	return &efs.Tag{
+		Key:   ec2Tag.Key,
+		Value: ec2Tag.Value,
+	}
+}
+
+func ensureNFSIngressRule(ec2svc *ec2.EC2, sgid string) {
+	dsgInput := &ec2.DescribeSecurityGroupsInput{
+		GroupIds: []*string{&sgid},
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String("ip-permission.to-port"),
+				Values: []*string{aws.String("2049")},
+			},
+		},
+	}
+	sgs, err := ec2svc.DescribeSecurityGroups(dsgInput)
+	if err != nil {
+		panic(err)
+	}
+	if len(sgs.SecurityGroups) != 0 {
+		log.Info("NFS ingress rule already exists; skipping.")
+		return
+	}
+
+	log.Info("Creating NFS ingress rule", "security group ID", sgid)
+	asgiInput := &ec2.AuthorizeSecurityGroupIngressInput{
+		// TODO(efried): Is this right, or too permissive?
+		CidrIp:     aws.String("0.0.0.0/0"),
+		FromPort:   aws.Int64(2049),
+		GroupId:    aws.String(sgid),
+		IpProtocol: aws.String("tcp"),
+		ToPort:     aws.Int64(2049),
+	}
+	if _, err := ec2svc.AuthorizeSecurityGroupIngress(asgiInput); err != nil {
+		panic(err)
+	}
+}
+
+// getFileSystems returns the current state of operator-managed file systems and
+// access points as a `fileSystems` structure.
+func getFileSystems(efssvc *efs.EFS) fileSystems {
+	fsret, err := efssvc.DescribeFileSystems(nil)
+	if err != nil {
+		panic(err)
+	}
+	fsmap := make(fileSystems)
+	for _, fsd := range fsret.FileSystems {
+		creationToken := *fsd.CreationToken
+		chunks := strings.Split(creationToken, ":")
+		if len(chunks) != 2 || chunks[0] != fsTokenMarker {
+			continue
+		}
+		fsKey := chunks[1]
+		fsid := fsd.FileSystemId
+		dapInput := &efs.DescribeAccessPointsInput{
+			FileSystemId: fsid,
+		}
+		apret, err := efssvc.DescribeAccessPoints(dapInput)
+		if err != nil {
+			panic(err)
+		}
+		aps := make(accessPoints)
+		for _, ap := range apret.AccessPoints {
+			clientToken := *ap.ClientToken
+			chunks := strings.Split(clientToken, ":")
+			if len(chunks) != 2 || chunks[0] != apTokenMarker {
+				continue
+			}
+			aps[chunks[1]] = *ap.AccessPointId
+		}
+		fsmap[fsKey] = fileSystem{
+			fileSystemID:       *fsid,
+			lastLifeCycleState: *fsd.LifeCycleState,
+			accessPoints:       aps,
+		}
+	}
+	return fsmap
+}
+
+// newFileSystem creates a new EFS file system and mount targets
+func newFileSystem(efssvc *efs.EFS, subnetIDs []*string, sgid string, ownedTag *efs.Tag, key string) string {
+	log.Info("Creating file system...", "key", key)
+	fsInput := &efs.CreateFileSystemInput{
+		CreationToken: aws.String(fmt.Sprintf("%s:%s", fsTokenMarker, key)),
+		// TODO(efried): Make this configurable
+		Encrypted: aws.Bool(true),
+		Tags:      []*efs.Tag{ownedTag},
+	}
+	fsd, err := efssvc.CreateFileSystem(fsInput)
+	if err != nil {
+		panic(err)
+	}
+	fsid := *fsd.FileSystemId
+	log.Info("Created new file system", "fsid", fsid)
+
+	return fsid
+}
+
+func waitForFSAvailable(efssvc *efs.EFS, fs fileSystem) {
+	dfsInput := &efs.DescribeFileSystemsInput{
+		FileSystemId: &fs.fileSystemID,
+	}
+	for fs.lastLifeCycleState != "available" {
+		time.Sleep(time.Second)
+		dfsOutput, err := efssvc.DescribeFileSystems(dfsInput)
+		if err != nil {
+			panic(err)
+		}
+		if len(dfsOutput.FileSystems) != 1 {
+			panic(fmt.Sprintf("Expected exactly one file system for ID %s but found %d",
+				fs.fileSystemID, len(dfsOutput.FileSystems)))
+		}
+		fs.lastLifeCycleState = *dfsOutput.FileSystems[0].LifeCycleState
+	}
+}
+
+func ensureMountTargets(efssvc *efs.EFS, fsid string, subnetIDs []*string, sgid string) {
+	log.Info("Creating mount targets...", "fsid", fsid)
+	for _, subnetID := range subnetIDs {
+		ensureMountTarget(efssvc, fsid, *subnetID, sgid)
+	}
+}
+
+func ensureMountTarget(efssvc *efs.EFS, fsid string, subnetID string, sgid string) {
+	cmtInput := &efs.CreateMountTargetInput{
+		FileSystemId:   aws.String(fsid),
+		SecurityGroups: []*string{aws.String(sgid)},
+		SubnetId:       aws.String(subnetID),
+	}
+	mtDesc, err := efssvc.CreateMountTarget(cmtInput)
+	if err != nil {
+		panic(err)
+	}
+	log.Info("Created mount target", "mount target ID", *mtDesc.MountTargetId)
+}
+
+func newAccessPoint(efssvc *efs.EFS, fsid string, key string) string {
+	log.Info("Creating access point...", "fsid", fsid, "key", key)
+	apInput := &efs.CreateAccessPointInput{
+		ClientToken:  aws.String(fmt.Sprintf("%s:%s", apTokenMarker, key)),
+		FileSystemId: aws.String(fsid),
+		RootDirectory: &efs.RootDirectory{
+			CreationInfo: &efs.CreationInfo{
+				// TODO(efried): Make these customizable
+				OwnerGid:    aws.Int64(0),
+				OwnerUid:    aws.Int64(0),
+				Permissions: aws.String("775"),
+			},
+			// Use the key, which is unique within this file system, as the subdirectory
+			Path: aws.String(fmt.Sprintf("/%s", key)),
+		},
+	}
+	apOutput, err := efssvc.CreateAccessPoint(apInput)
+	if err != nil {
+		panic(err)
+	}
+	return *apOutput.AccessPointId
+}
+
+func deleteMountTargets(efssvc *efs.EFS, fsid string) {
+	log.Info("Deleting mount targets", "fsid", fsid)
+	descInput := &efs.DescribeMountTargetsInput{
+		FileSystemId: aws.String(fsid),
+	}
+	// Loop until the mount targets are gone
+	for {
+		descOutput, err := efssvc.DescribeMountTargets(descInput)
+		if err != nil {
+			panic(err)
+		}
+		if len(descOutput.MountTargets) == 0 {
+			// They're all gone
+			break
+		}
+		for _, mt := range descOutput.MountTargets {
+			log.Info("Deleting mount target.", "mount target ID", *mt.MountTargetId)
+			delInput := &efs.DeleteMountTargetInput{
+				MountTargetId: mt.MountTargetId,
+			}
+			if _, err := efssvc.DeleteMountTarget(delInput); err != nil {
+				if _, ok := err.(*efs.MountTargetNotFound); !ok {
+					panic(err)
+				}
+			}
+		}
+
+	}
+}
+
+func deleteFileSystem(efssvc *efs.EFS, fsid string) {
+	deleteMountTargets(efssvc, fsid)
+	log.Info("Removing file system...", "fsid", fsid)
+	dfsInput := &efs.DeleteFileSystemInput{
+		FileSystemId: aws.String(fsid),
+	}
+	if _, err := efssvc.DeleteFileSystem(dfsInput); err != nil {
+		panic(fmt.Sprintf("Couldn't remove file system %s: %v", fsid, err))
+	}
+}
+
+func ensureFileSystemState(desired fileSystems) {
+	// Set up API services
+	sess := getSession()
+	ec2svc := getEC2(sess)
+	efssvc := getEFS(sess)
+
+	// Gather info about worker instances
+	workers := getWorkers(ec2svc)
+	sgid := getSecurityGroupID(workers)
+	subnetIDs := getSubnetIDs(workers)
+	ec2Tag := getOwnedTag(workers)
+	ensureNFSIngressRule(ec2svc, sgid)
+
+	// We'll use the "same" owned tag for file systems as for worker nodes
+	efsTag := tagEC2ToEFS(ec2Tag)
+
+	// Map the current state of operator-managed file systems and access points
+	currentState := getFileSystems(efssvc)
+
+	// Now reconcile the current state with the desired state
+	// First remove any extraneous file systems.
+	for fskey, currentfs := range currentState {
+		if _, ok := desired[fskey]; ok {
+			// It's a desired file system, so leave it
+			continue
+		}
+		deleteFileSystem(efssvc, currentfs.fileSystemID)
+	}
+
+	// Now create any file systems that don't exist yet
+	for fskey, desiredfs := range desired {
+		var fsid string
+		currentfs, ok := currentState[fskey]
+		if ok {
+			fsid = currentfs.fileSystemID
+		} else {
+			fsid = newFileSystem(efssvc, subnetIDs, sgid, efsTag, fskey)
+			currentfs = fileSystem{
+				fileSystemID: fsid,
+				accessPoints: make(accessPoints),
+			}
+			currentState[fskey] = currentfs
+		}
+		waitForFSAvailable(efssvc, currentfs)
+		ensureMountTargets(efssvc, fsid, subnetIDs, sgid)
+
+		for apkey := range desiredfs.accessPoints {
+			if _, ok := currentfs.accessPoints[apkey]; ok {
+				// Access point already exists
+				continue
+			}
+			apid := newAccessPoint(efssvc, fsid, apkey)
+			currentfs.accessPoints[apkey] = apid
+		}
+	}
+}

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -309,6 +309,15 @@ func deleteFileSystem(efssvc *efs.EFS, fsid string) {
 	}
 }
 
+func deleteEverything() {
+	sess := getSession()
+	efssvc := getEFS(sess)
+	currentState := getFileSystems(efssvc)
+	for _, currentfs := range currentState {
+		deleteFileSystem(efssvc, currentfs.fileSystemID)
+	}
+}
+
 func ensureFileSystemState(desired fileSystems) {
 	// Set up API services
 	sess := getSession()

--- a/pkg/aws/main.go
+++ b/pkg/aws/main.go
@@ -14,7 +14,7 @@ type spec map[string][]string
 func usage() {
 	fmt.Fprintf(
 		flag.CommandLine.Output(),
-		"Usage: %s {--spec PATH | --delete-all}\n\n", os.Args[0])
+		"Usage: %s {--spec PATH | --discover | --delete-all}\n\n", os.Args[0])
 	flag.PrintDefaults()
 }
 
@@ -43,22 +43,40 @@ have two access points; the third will have none.`)
 		false,
 		"Delete all mount targets, file systems, and access points.")
 
+	var discover = flag.Bool(
+		"discover",
+		false,
+		`Discover and print file system and access point pairs, one per line, e.g.
+    fs-a99c122a:fsap-099537fb4bb7d50ea
+    fs-b89c123b:fsap-04e855ae78fe51eed
+    fs-b89c123b:fsap-0b02dc545c4f9b076`)
+
 	flag.Parse()
 
-	if *specfile == "" && !*deleteAll {
-		usage()
-		os.Exit(1)
+	numopts := 0
+	if *specfile != "" {
+		numopts++
 	}
-
-	if *specfile != "" && *deleteAll {
+	if *deleteAll {
+		numopts++
+	}
+	if *discover {
+		numopts++
+	}
+	if numopts != 1 {
 		fmt.Fprintf(
 			flag.CommandLine.Output(),
-			"--spec and --delete-all are mutually exclusive.\nUse -h for help.\n")
+			"Must specify exactly one of --spec, --delete-all, and --discover.\nUse -h for help.\n")
 		os.Exit(2)
 	}
 
 	if *deleteAll {
 		deleteEverything()
+		os.Exit(0)
+	}
+
+	if *discover {
+		discoverPrint()
 		os.Exit(0)
 	}
 

--- a/pkg/aws/main.go
+++ b/pkg/aws/main.go
@@ -1,6 +1,10 @@
 package main
 
 func main() {
+	// TODO(efried): Process CLI like:
+	// $0 {-f|--file} path/to/spec.yaml | {-D|--delete-all}
+
+	// deleteEverything()
 	desiredState := fileSystems{
 		"fs1": fileSystem{
 			accessPoints: accessPoints{

--- a/pkg/aws/main.go
+++ b/pkg/aws/main.go
@@ -1,22 +1,85 @@
 package main
 
-func main() {
-	// TODO(efried): Process CLI like:
-	// $0 {-f|--file} path/to/spec.yaml | {-D|--delete-all}
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
 
-	// deleteEverything()
-	desiredState := fileSystems{
-		"fs1": fileSystem{
-			accessPoints: accessPoints{
-				"apX": "",
-			},
-		},
-		"fs2": fileSystem{
-			accessPoints: accessPoints{
-				"apY": "",
-				"apZ": "",
-			},
-		},
+	"sigs.k8s.io/yaml"
+)
+
+type spec map[string][]string
+
+func usage() {
+	fmt.Fprintf(
+		flag.CommandLine.Output(),
+		"Usage: %s {--spec PATH | --delete-all}\n\n", os.Args[0])
+	flag.PrintDefaults()
+}
+
+func main() {
+	flag.Usage = usage
+
+	var specfile = flag.String(
+		"spec",
+		"",
+		`Path to a YAML spec file describing the desired file system and access point state.
+The file represents a map, keyed by file system "token", of lists of access point "tokens".
+(These tokens are arbitrary unique strings used to ensure idempotency.) For example:
+
+    fs1:
+        - apX
+    fs2:
+        - apY
+        - apZ
+    fs3: []
+
+This will create three file systems. The first will have one access point; the second will
+have two access points; the third will have none.`)
+
+	var deleteAll = flag.Bool(
+		"delete-all",
+		false,
+		"Delete all mount targets, file systems, and access points.")
+
+	flag.Parse()
+
+	if *specfile == "" && !*deleteAll {
+		usage()
+		os.Exit(1)
+	}
+
+	if *specfile != "" && *deleteAll {
+		fmt.Fprintf(
+			flag.CommandLine.Output(),
+			"--spec and --delete-all are mutually exclusive.\nUse -h for help.\n")
+		os.Exit(2)
+	}
+
+	if *deleteAll {
+		deleteEverything()
+		os.Exit(0)
+	}
+
+	y, err := ioutil.ReadFile(*specfile)
+	if err != nil {
+		panic(err)
+	}
+	specmap := make(spec)
+	err = yaml.Unmarshal(y, &specmap)
+	if err != nil {
+		panic(err)
+	}
+
+	desiredState := make(fileSystems)
+	for fskey, aplist := range specmap {
+		desiredState[fskey] = fileSystem{
+			accessPoints: make(accessPoints),
+		}
+		for _, apkey := range aplist {
+			desiredState[fskey].accessPoints[apkey] = ""
+		}
 	}
 	ensureFileSystemState(desiredState)
 }

--- a/pkg/aws/main.go
+++ b/pkg/aws/main.go
@@ -1,0 +1,18 @@
+package main
+
+func main() {
+	desiredState := fileSystems{
+		"fs1": fileSystem{
+			accessPoints: accessPoints{
+				"apX": "",
+			},
+		},
+		"fs2": fileSystem{
+			accessPoints: accessPoints{
+				"apY": "",
+				"apZ": "",
+			},
+		},
+	}
+	ensureFileSystemState(desiredState)
+}

--- a/pkg/aws/spec_sample.yaml
+++ b/pkg/aws/spec_sample.yaml
@@ -1,0 +1,6 @@
+fs1:
+    - apX
+fs2:
+    - apY
+    - apZ
+fs3: []


### PR DESCRIPTION
This is mostly a port of the functionality in
[these scripts](https://gitlab.cee.redhat.com/service/osd-efs/tree/master/scripts)
to manage creation/deletion of EFS file systems and access points.

It's pretty rough right now, not ready for production use, intended for
development, testing, demoing, etc.

You can use it by filling in the structure in pkg/aws/main.go with a
tree of file systems and access points, and then running that `main()`.