### PR TITLE
Create a `pr-check` `make` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,7 @@ docker-build: build
 # Push the docker image
 .PHONY: docker-push
 docker-push: push
+
+.PHONY: pr-check
+pr-check:
+	hack/app_sre_pr_check.sh


### PR DESCRIPTION
This is a step toward being able to customize-and-standardize the nature
and location of what gets run in the jenkins pipeline. By hiding what
we're running under a generic `pr-check` target, we can tweak what's
actually happening without having to update the jenkins job every time.