### PR TITLE
Only support `AllNamespaces`

### DIFF
--- a/config/templates/aws-efs-operator-csv-template.yaml
+++ b/config/templates/aws-efs-operator-csv-template.yaml
@@ -24,7 +24,7 @@ spec:
   maturity: alpha
   installModes:
   - type: OwnNamespace
-    supported: true
+    supported: false
   - type: SingleNamespace
     supported: false
   - type: MultiNamespace


### PR DESCRIPTION
As a community operator, it is important that we only allow the
`AllNamespaces` install mode.

A single namespace makes for poor UX in the web console: you can then
only create SharedVolume resources with the generic `+` at the top
right; and you can only view them via the generic `Search` function.

And multiple instances of the operator (which are possible at least
under `OwnNamespace`) conflict and wind up thrashing the ServiceAccount
trying to keep it in their own namespace.

What `AllNamespaces` seems to do is actually install the operator
exactly once (when done from the OperatorHub in the OCM web console, it
goes into the `openshift-operators` namespace) but make its CRD
available in all namespaces. That's what we want.