### PR TITLE
Update for latest CSI driver image post issues/167

### DIFF
--- a/pkg/controller/sharedvolume/ensurables_test.go
+++ b/pkg/controller/sharedvolume/ensurables_test.go
@@ -73,10 +73,12 @@ func TestPVEnsurable(t *testing.T) {
 	if !equal(actualDef, expectedDef) {
 		t.Fatalf("Expected defs to be equal:\n%v\n%v", actualDef, expectedDef)
 	}
-	// Now muck with something we care about
+	// Now muck with something we care about. Since we're using AlwaysEqual (see NOTE on
+	// pvEnsurable's EqualFunc), it will evaluate equal anyway.
 	actualDef.(*corev1.PersistentVolume).Spec.AccessModes[0] = corev1.ReadOnlyMany
-	if equal(actualDef, expectedDef) {
-		t.Fatalf("Expected defs not to be equal:\n%v\n%v", actualDef, expectedDef)
+	if !equal(actualDef, expectedDef) {
+		t.Fatalf("Expected defs to evaluate equal (even though they're not):\n%v\n%v",
+			format(actualDef), format(expectedDef))
 	}
 }
 

--- a/pkg/controller/sharedvolume/ensurables_test.go
+++ b/pkg/controller/sharedvolume/ensurables_test.go
@@ -3,6 +3,7 @@ package sharedvolume
 // Test cases for the PV and PVC Ensurables
 
 import (
+	"fmt"
 	awsefsv1alpha1 "openshift/aws-efs-operator/pkg/apis/awsefs/v1alpha1"
 	"openshift/aws-efs-operator/pkg/test"
 	util "openshift/aws-efs-operator/pkg/util"
@@ -132,12 +133,12 @@ func TestCache(t *testing.T) {
 
 	// PVs
 	pv1 := pvEnsurable(&sharedVolume).(*util.EnsurableImpl).Definition.(*corev1.PersistentVolume)
-	expVolumeHandle1 := fakeFSID + "::" + fakeAPID
+	expVolumeHandle1 := fmt.Sprintf("%s::%s", fakeFSID, fakeAPID)
 	if pv1.Spec.CSI.VolumeHandle != expVolumeHandle1 {
 		t.Fatalf("Expected PV ensurable to correspond to\nSharedVolume %v\nbut got\nPV %v",
 			format(sharedVolume), format(pv1))
 	}
-	expVolumeHandle2 := fsid2 + "::" + apid2
+	expVolumeHandle2 := fmt.Sprintf("%s::%s", fsid2, apid2)
 	pv2 := pvEnsurable(&sv2).(*util.EnsurableImpl).Definition.(*corev1.PersistentVolume)
 	if pv2.Spec.CSI.VolumeHandle != expVolumeHandle2 {
 		t.Fatalf("Expected PV ensurable to correspond to\nSharedVolume %v\nbut got\nPV %v",

--- a/pkg/controller/sharedvolume/ensurables_test.go
+++ b/pkg/controller/sharedvolume/ensurables_test.go
@@ -130,12 +130,14 @@ func TestCache(t *testing.T) {
 
 	// PVs
 	pv1 := pvEnsurable(&sharedVolume).(*util.EnsurableImpl).Definition.(*corev1.PersistentVolume)
-	if pv1.Spec.CSI.VolumeHandle != fakeFSID {
+	expVolumeHandle1 := fakeFSID + "::" + fakeAPID
+	if pv1.Spec.CSI.VolumeHandle != expVolumeHandle1 {
 		t.Fatalf("Expected PV ensurable to correspond to\nSharedVolume %v\nbut got\nPV %v",
 			format(sharedVolume), format(pv1))
 	}
+	expVolumeHandle2 := fsid2 + "::" + apid2
 	pv2 := pvEnsurable(&sv2).(*util.EnsurableImpl).Definition.(*corev1.PersistentVolume)
-	if pv2.Spec.CSI.VolumeHandle != fsid2 {
+	if pv2.Spec.CSI.VolumeHandle != expVolumeHandle2 {
 		t.Fatalf("Expected PV ensurable to correspond to\nSharedVolume %v\nbut got\nPV %v",
 			format(sv2), format(pv2))
 	}

--- a/pkg/controller/sharedvolume/pv_ensurable.go
+++ b/pkg/controller/sharedvolume/pv_ensurable.go
@@ -27,9 +27,10 @@ func pvEnsurable(sharedVolume *awsefsv1alpha1.SharedVolume) util.Ensurable {
 			// NOTE: PVs are immutable once created, so theoretically we should never encounter an
 			// event that requires an actual update. And if we did, we wouldn't be able to update
 			// anyway, so pretend the change didn't happen.
-			// The exception is an upgrade like the one from 0.0.2, where the shape of a SV-backed
+			// The exception is an upgrade like this one [1], where the shape of a SV-backed
 			// PV changed, meaning that if the operator notices an old-style PV, it will try to
 			// "fix" it. Which won't work. Spoofing "always equal" will avoid that.
+			// [1] https://github.com/openshift/aws-efs-operator/pull/17/commits/bfcfcda1158510a28cc253a76c74fd03edd20a4f#diff-b7b6189fad2ed163b0a2ff5f7f22ad50L73-L81
 			EqualFunc: util.AlwaysEqual,
 		}
 	}

--- a/pkg/controller/sharedvolume/pv_ensurable.go
+++ b/pkg/controller/sharedvolume/pv_ensurable.go
@@ -56,6 +56,7 @@ func pvEqual(local, server runtime.Object) bool {
 
 func pvDefinition(sharedVolume *awsefsv1alpha1.SharedVolume) *corev1.PersistentVolume {
 	filesystem := corev1.PersistentVolumeFilesystem
+	volumeHandle := fmt.Sprintf("%s::%s", sharedVolume.Spec.FileSystemID, sharedVolume.Spec.AccessPointID)
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pvNameForSharedVolume(sharedVolume),
@@ -70,14 +71,10 @@ func pvDefinition(sharedVolume *awsefsv1alpha1.SharedVolume) *corev1.PersistentV
 			AccessModes:                   []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},
 			PersistentVolumeReclaimPolicy: corev1.PersistentVolumeReclaimRetain,
 			StorageClassName:              statics.StorageClassName,
-			MountOptions: []string{
-				"tls",
-				fmt.Sprintf("accesspoint=%s", sharedVolume.Spec.AccessPointID),
-			},
 			PersistentVolumeSource: corev1.PersistentVolumeSource{
 				CSI: &corev1.CSIPersistentVolumeSource{
 					Driver:       statics.CSIDriverName,
-					VolumeHandle: sharedVolume.Spec.FileSystemID,
+					VolumeHandle: volumeHandle,
 				},
 			},
 		},

--- a/pkg/controller/sharedvolume/pvc_ensurable.go
+++ b/pkg/controller/sharedvolume/pvc_ensurable.go
@@ -26,6 +26,11 @@ func pvcEnsurable(sharedVolume *awsefsv1alpha1.SharedVolume) util.Ensurable {
 			ObjType:        &corev1.PersistentVolumeClaim{},
 			NamespacedName: pvcNamespacedName(sharedVolume),
 			Definition:     pvcDefinition(sharedVolume),
+			// PVCs are (almost*) immutable once created, so doing an equals check is probably
+			// always a no-op, and we could use AlwaysEqual here instead. But it's harmless for
+			// now, so leave it.
+			// * except for the size, if supported, which in the case of EFS it's not,
+			//   and wouldn't make sense anyway, because elastic.
 			EqualFunc: func(local, server runtime.Object) bool {
 				return reflect.DeepEqual(
 					local.(*corev1.PersistentVolumeClaim).Spec,

--- a/pkg/controller/sharedvolume/sharedvolume_controller_test.go
+++ b/pkg/controller/sharedvolume/sharedvolume_controller_test.go
@@ -316,7 +316,7 @@ func TestReconcile(t *testing.T) {
 	pv.Spec.CSI.VolumeHandle = fs1
 	pv.Spec.MountOptions = []string{
 		"tls",
-		"accesspoint=" + apd,
+		fmt.Sprintf("accesspoint=%s", apd),
 	}
 	if err = r.client.Update(ctx, pv); err != nil {
 		t.Fatal(err)
@@ -401,7 +401,7 @@ func TestReconcile(t *testing.T) {
 	recoverPV()
 
 	// 3) VolumeHandle is downright malformed
-	bogusVolHandle := fs1 + ":" + apd
+	bogusVolHandle := fmt.Sprintf("%s:%s", fs1, apd)
 	pv.Spec.CSI.VolumeHandle = bogusVolHandle
 	if err = r.client.Update(ctx, pv); err != nil {
 		t.Fatal(err)
@@ -622,7 +622,7 @@ func TestUneditUpdateError(t *testing.T) {
 type matchFinalizer struct{}
 
 func (m matchFinalizer) String() string {
-	return "has finalizer " + svFinalizer
+	return fmt.Sprintf("has finalizer %s", svFinalizer)
 }
 func (m matchFinalizer) Matches(x interface{}) bool {
 	finalizers := x.(metav1.Object).GetFinalizers()

--- a/pkg/controller/sharedvolume/testdata/persistentvolume.yaml
+++ b/pkg/controller/sharedvolume/testdata/persistentvolume.yaml
@@ -11,11 +11,7 @@ spec:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
   storageClassName: efs-sc
-  mountOptions:
-  - tls
-  # File system access point ID
-  - accesspoint=fsap-0123456789abcdef
   csi:
     driver: efs.csi.aws.com
     # EFS volume ID
-    volumeHandle: fs-0123cdef
+    volumeHandle: fs-0123cdef::fsap-0123456789abcdef

--- a/pkg/controller/statics/defs/daemonset.yaml
+++ b/pkg/controller/statics/defs/daemonset.yaml
@@ -20,6 +20,8 @@ spec:
       # DELTA: Removed
       # priorityClassName: system-node-critical
       nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
         # DELTA: only deploy this on worker nodes
         # NOTE: This will hit infra nodes as well.
         node-role.kubernetes.io/worker: ''
@@ -51,6 +53,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               hostPort: 9809
@@ -65,7 +69,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           # DELTA: Always pull
           imagePullPolicy: Always
           args:
@@ -88,7 +92,7 @@ spec:
               mountPath: /registration
         - name: liveness-probe
           imagePullPolicy: Always
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809
@@ -111,4 +115,8 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/pkg/controller/statics/statics.go
+++ b/pkg/controller/statics/statics.go
@@ -13,15 +13,12 @@ import (
 	"reflect"
 
 	"github.com/go-logr/logr"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	securityv1 "github.com/openshift/api/security/v1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	storagev1beta1 "k8s.io/api/storage/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -101,14 +98,14 @@ func init() {
 			ObjType:        &corev1.ServiceAccount{},
 			NamespacedName: getNSName(saDef),
 			Definition:     saDef,
-			EqualFunc:      alwaysEqual,
+			EqualFunc:      util.AlwaysEqual,
 		},
 		&util.EnsurableImpl{
 			ObjType:        &securityv1.SecurityContextConstraints{},
 			NamespacedName: getNSName(sccDef),
 			Definition:     sccDef,
 			// SCC has no Spec; the meat is at the top level
-			EqualFunc: equalOtherThanMeta,
+			EqualFunc: util.EqualOtherThanMeta,
 		},
 		&util.EnsurableImpl{
 			ObjType:        &appsv1.DaemonSet{},
@@ -127,7 +124,7 @@ func init() {
 			NamespacedName: getNSName(scDef),
 			Definition:     scDef,
 			// StorageClass has no Spec; the meat is at the top level
-			EqualFunc: equalOtherThanMeta,
+			EqualFunc: util.EqualOtherThanMeta,
 		},
 	}
 
@@ -209,19 +206,6 @@ func EnsureStatics(log logr.Logger, client crclient.Client) error {
 		return fmt.Errorf("Encountered %d error(s) ensuring statics", errcount)
 	}
 	return nil
-}
-
-// alwaysEqual is a convenience implementation of static.equalFunc for objects that can't change
-// (in any significant way)
-func alwaysEqual(local, server runtime.Object) bool {
-	return true
-}
-
-// equalOtherThanMeta is a DeepEquals that ignores ObjectMeta and TypeMeta.
-// Use when a DeepEqual on Spec won't work, e.g. when the meat of the object is at the top level
-// and/or there _is_ no Spec.
-func equalOtherThanMeta(local, server runtime.Object) bool {
-	return cmp.Equal(local, server, cmpopts.IgnoreTypes(metav1.ObjectMeta{}, metav1.TypeMeta{}))
 }
 
 func csiDriverEqual(local, server runtime.Object) bool {

--- a/pkg/controller/statics/statics.go
+++ b/pkg/controller/statics/statics.go
@@ -136,14 +136,14 @@ func init() {
 
 func loadDefTemplate(receiver runtime.Object, defFile string) {
 	if err := yaml.Unmarshal(MustAsset(filepath.Join("defs", defFile)), receiver); err != nil {
-		panic("Couldn't load " + defFile + ": " + err.Error())
+		panic(fmt.Sprintf("Couldn't load %s: %s", defFile, err.Error()))
 	}
 }
 
 func getNSName(definition runtime.Object) types.NamespacedName {
 	nsname, err := crclient.ObjectKeyFromObject(definition)
 	if err != nil {
-		panic("Couldn't extract NamespacedName from definition: " + err.Error())
+		panic(fmt.Sprintf("Couldn't extract NamespacedName from definition: %s", err.Error()))
 	}
 	return nsname
 }
@@ -173,12 +173,12 @@ func discoverNamespace() {
 	// TODO(efried): Is there a better / more accepted / canonical way to do this?
 	apiConfig, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
 	if err != nil {
-		panic("Couldn't discover cluster config: " + err.Error())
+		panic(fmt.Sprintf("Couldn't discover cluster config: %s", err.Error()))
 	}
 	clientConfig := clientcmd.NewDefaultClientConfig(*apiConfig, &clientcmd.ConfigOverrides{})
 	namespaceName, _, err = clientConfig.Namespace()
 	if err != nil {
-		panic("Couldn't get namespace from cluster config: " + err.Error())
+		panic(fmt.Sprintf("Couldn't get namespace from cluster config: %s", err.Error()))
 	}
 	glog.Info("Discovered namespace from config.", "namespace", namespaceName)
 }

--- a/pkg/controller/statics/statics_test.go
+++ b/pkg/controller/statics/statics_test.go
@@ -171,7 +171,10 @@ func Test_static_GetType(t *testing.T) {
 	}
 }
 
-func Test_alwaysEqual(t *testing.T) {
+// Test_AlwaysEqual should really live in ensurable_test.go (TODO) but that will entail changing
+// the "Things that are super different" test case in some nontrivial way, since `staticResources`
+// isn't exported.
+func Test_AlwaysEqual(t *testing.T) {
 	// This is kind of silly, but...
 	type args struct {
 		local  runtime.Object
@@ -190,8 +193,8 @@ func Test_alwaysEqual(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := alwaysEqual(tt.args.local, tt.args.server); !got {
-				t.Errorf("alwaysEqual() = %v, want true", got)
+			if got := util.AlwaysEqual(tt.args.local, tt.args.server); !got {
+				t.Errorf("AlwaysEqual() = %v, want true", got)
 			}
 		})
 	}
@@ -201,23 +204,23 @@ func Test_storageClassEqual(t *testing.T) {
 	sc1 := staticResourceMap[StorageClassName].(*util.EnsurableImpl).Definition.(*storagev1.StorageClass)
 	sc2 := sc1.DeepCopy()
 
-	if !equalOtherThanMeta(sc1, sc1) {
+	if !util.EqualOtherThanMeta(sc1, sc1) {
 		t.Error("Expected object to compare equal to itself.")
 	}
 
-	if !equalOtherThanMeta(sc1, sc2) {
+	if !util.EqualOtherThanMeta(sc1, sc2) {
 		t.Errorf("Getter should always return objects that compare equal.\n%v\n%v", sc1, sc2)
 	}
 
 	// Mucking with metadata shouldn't affect equality
 	sc2.ObjectMeta.SelfLink = "/foo/bar/baz"
-	if !equalOtherThanMeta(sc1, sc2) {
+	if !util.EqualOtherThanMeta(sc1, sc2) {
 		t.Errorf("Metadata should not affect equality.\n%v\n%v", sc1, sc2)
 	}
 
 	// But these fields should
 	sc2.Provisioner = "foo"
-	if equalOtherThanMeta(sc1, sc2) {
+	if util.EqualOtherThanMeta(sc1, sc2) {
 		t.Errorf("Change of Provisioner should make these unequal.\n%v\n%v", sc1, sc2)
 	}
 	// reset
@@ -225,7 +228,7 @@ func Test_storageClassEqual(t *testing.T) {
 
 	recycle := corev1.PersistentVolumeReclaimRecycle
 	sc2.ReclaimPolicy = &recycle
-	if equalOtherThanMeta(sc1, sc2) {
+	if util.EqualOtherThanMeta(sc1, sc2) {
 		t.Errorf("Change of ReclaimPolicy should make these unequal.\n%v\n%v", sc1, sc2)
 	}
 	// reset
@@ -233,7 +236,7 @@ func Test_storageClassEqual(t *testing.T) {
 
 	wf1c := storagev1.VolumeBindingWaitForFirstConsumer
 	sc2.VolumeBindingMode = &wf1c
-	if equalOtherThanMeta(sc1, sc2) {
+	if util.EqualOtherThanMeta(sc1, sc2) {
 		t.Errorf("Change of VolumeBindingMode should make these unequal.\n%v\n%v", sc1, sc2)
 	}
 }
@@ -268,35 +271,35 @@ func Test_securityContextConstraintsEqual(t *testing.T) {
 	scc1 := staticResourceMap[sccName].(*util.EnsurableImpl).Definition.(*securityv1.SecurityContextConstraints)
 	scc2 := scc1.DeepCopy()
 
-	if !equalOtherThanMeta(scc1, scc1) {
+	if !util.EqualOtherThanMeta(scc1, scc1) {
 		t.Error("Expected object to compare equal to itself.")
 	}
 
-	if !equalOtherThanMeta(scc1, scc2) {
+	if !util.EqualOtherThanMeta(scc1, scc2) {
 		t.Errorf("Getter should always return objects that compare equal.\n%v\n%v", scc1, scc2)
 	}
 
 	// Mucking with metadata shouldn't affect equality
 	scc2.ObjectMeta.SelfLink = "/foo/bar/baz"
-	if !equalOtherThanMeta(scc1, scc2) {
+	if !util.EqualOtherThanMeta(scc1, scc2) {
 		t.Errorf("Metadata should not affect equality.\n%v\n%v", scc1, scc2)
 	}
 
 	// Pick a few fields to test
 	scc2.AllowHostIPC = false
-	if equalOtherThanMeta(scc1, scc2) {
+	if util.EqualOtherThanMeta(scc1, scc2) {
 		t.Errorf("Changing AllowHostIPC should make these unequal.\n%v\n%v", scc1, scc2)
 	}
 	scc2.AllowHostIPC = true
 
 	scc2.RunAsUser.Type = securityv1.RunAsUserStrategyMustRunAs
-	if equalOtherThanMeta(scc1, scc2) {
+	if util.EqualOtherThanMeta(scc1, scc2) {
 		t.Errorf("Changing RunAsUser.Type should make these unequal.\n%v\n%v", scc1, scc2)
 	}
 	scc2.RunAsUser.Type = securityv1.RunAsUserStrategyRunAsAny
 
 	scc2.Users = append(scc2.Users, "foo")
-	if equalOtherThanMeta(scc1, scc2) {
+	if util.EqualOtherThanMeta(scc1, scc2) {
 		t.Errorf("Changing Users should make these unequal.\n%v\n%v", scc1, scc2)
 	}
 }

--- a/pkg/controller/statics/zz_generated_defs.go
+++ b/pkg/controller/statics/zz_generated_defs.go
@@ -106,6 +106,8 @@ spec:
       # DELTA: Removed
       # priorityClassName: system-node-critical
       nodeSelector:
+        kubernetes.io/os: linux
+        kubernetes.io/arch: amd64
         # DELTA: only deploy this on worker nodes
         # NOTE: This will hit infra nodes as well.
         node-role.kubernetes.io/worker: ''
@@ -137,6 +139,8 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
+            - name: efs-utils-config
+              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               hostPort: 9809
@@ -151,7 +155,7 @@ spec:
             periodSeconds: 2
             failureThreshold: 5
         - name: csi-driver-registrar
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.3.0
           # DELTA: Always pull
           imagePullPolicy: Always
           args:
@@ -174,7 +178,7 @@ spec:
               mountPath: /registration
         - name: liveness-probe
           imagePullPolicy: Always
-          image: quay.io/k8scsi/livenessprobe:v1.1.0
+          image: quay.io/k8scsi/livenessprobe:v2.0.0
           args:
             - --csi-address=/csi/csi.sock
             - --health-port=9809
@@ -197,6 +201,10 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
+            type: DirectoryOrCreate
+        - name: efs-utils-config
+          hostPath:
+            path: /etc/amazon/efs
             type: DirectoryOrCreate
 `)
 


### PR DESCRIPTION
Since the [fix](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/185) for [issue #167](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/167) merged upstream, the AWS EFS CSI driver team overwrote the [`latest` image tag](sha256-962619a5deb34e1c4257f2120dd941ab026fc96adde003e27f70b65023af5a07?context=explore) to include it.

For starters, this means we can update this operator to use the [new method of specifying access points](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/0ae998c5a95fe6dbee7f43c182997e64872695e6/examples/kubernetes/access_points#edit-persistent-volume-spec) via a colon-delimited `volumeHandle` as opposed to in `mountOptions`.

However, the same update to `latest` also brought in a [commit](https://github.com/kubernetes-sigs/aws-efs-csi-driver/commit/b3baff821a477161599eef757c5ed59dc7126073) that requires an additional mount in the `efs-plugin` container of the DaemonSet. So we need to update our YAML for that resource at the same time, or everything is broken (this might be upstream [issue #192](https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/192)). This update to the DaemonSet YAML also syncs with [upstream](https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/0ae998c5a95fe6dbee7f43c182997e64872695e6/deploy/kubernetes/base/node.yaml) by bumping the image versions for the other two containers (csi-node-driver-registrar: v1.1.0 => v1.3.0; and livenessprobe: v1.1.0 => livenessprobe:v2.0.0).

Jira: [OSD-4187](https://issues.redhat.com/browse/OSD-4187)