### PR TITLE
Pin driver to a commit tag

### DIFF
--- a/pkg/controller/statics/defs/daemonset.yaml
+++ b/pkg/controller/statics/defs/daemonset.yaml
@@ -35,7 +35,8 @@ spec:
           # DELTA: fq image
           # TODO(efried): Pin to a release
           #  https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/152
-          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:latest
+          # For now, freeze to a known working commit tag
+          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:778131e
           # DELTA: Always pull
           imagePullPolicy: Always
           args:
@@ -53,8 +54,6 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
-            - name: efs-utils-config
-              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               hostPort: 9809
@@ -115,8 +114,4 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
-            type: DirectoryOrCreate
-        - name: efs-utils-config
-          hostPath:
-            path: /etc/amazon/efs
             type: DirectoryOrCreate

--- a/pkg/controller/statics/zz_generated_defs.go
+++ b/pkg/controller/statics/zz_generated_defs.go
@@ -121,7 +121,8 @@ spec:
           # DELTA: fq image
           # TODO(efried): Pin to a release
           #  https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/152
-          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:latest
+          # For now, freeze to a known working commit tag
+          image: registry.hub.docker.com/amazon/aws-efs-csi-driver:778131e
           # DELTA: Always pull
           imagePullPolicy: Always
           args:
@@ -139,8 +140,6 @@ spec:
               mountPath: /csi
             - name: efs-state-dir
               mountPath: /var/run/efs
-            - name: efs-utils-config
-              mountPath: /etc/amazon/efs
           ports:
             - containerPort: 9809
               hostPort: 9809
@@ -201,10 +200,6 @@ spec:
         - name: efs-state-dir
           hostPath:
             path: /var/run/efs
-            type: DirectoryOrCreate
-        - name: efs-utils-config
-          hostPath:
-            path: /etc/amazon/efs
             type: DirectoryOrCreate
 `)
 


### PR DESCRIPTION
Since [upstream PR #202](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/202), the upstream aws-efs-csi-driver has been saving images tagged according to commit hashes as well as simply moving `latest` along. This commit locks our operator into using the tag corresponding to commit [778131e](https://github.com/kubernetes-sigs/aws-efs-csi-driver/tree/778131e6fdfce466bbada3fb08b1e5bdd50c072b), including updating the daemonset yaml to match what's at that commit level.