### PR TITLE
Make PV/PVC owned by SharedVolume

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ This operator is available via OperatorHub.
 More detailed information can be found [here](https://access.redhat.com/articles/5025181).
 
 ## Uninstalling
-1. Uninstall via OperatorHub
-2. Manually delete the `efs-csi-scc` SecurityContextConstraints (see [below](#securitycontextconstraints-must-be-deleted-manually))
+Uninstall via OperatorHub.
 
 ## Usage
 
@@ -187,15 +186,6 @@ can leave it in an unusable state, even if the operator is able to resurrect the
 
 The only supported way to delete a `PersistentVolumeClaim` (or `PersistentVolume`) associated with a `SharedVolume`
 is to delete the `SharedVolume` and let the operator do the rest.
-
-### SecurityContextConstraints must be deleted manually
-Per [issue #23](https://github.com/openshift/aws-efs-operator/issues/23), uninstalling the operator may not clean up the `efs-csi-scc` SecurityContextConstraints. To delete it manually:
-
-```shell
-$ oc delete scc efs-csi-scc
-```
-
-This may require special permissions.
 
 ## Under the hood
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ This operator is available via OperatorHub.
 More detailed information can be found [here](https://access.redhat.com/articles/5025181).
 
 ## Uninstalling
-TODO (don't forget about manual cleanup of statics)
+1. Uninstall via OperatorHub
+2. Manually delete the `efs-csi-scc` SecurityContextConstraints (see [below](#securitycontextconstraints-must-be-deleted-manually))
 
 ## Usage
 
@@ -186,6 +187,15 @@ can leave it in an unusable state, even if the operator is able to resurrect the
 
 The only supported way to delete a `PersistentVolumeClaim` (or `PersistentVolume`) associated with a `SharedVolume`
 is to delete the `SharedVolume` and let the operator do the rest.
+
+### SecurityContextConstraints must be deleted manually
+Per [issue #23](https://github.com/openshift/aws-efs-operator/issues/23), uninstalling the operator may not clean up the `efs-csi-scc` SecurityContextConstraints. To delete it manually:
+
+```shell
+$ oc delete scc efs-csi-scc
+```
+
+This may require special permissions.
 
 ## Under the hood
 

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/client-go/rest"
@@ -139,6 +140,12 @@ func main() {
 
 	// Add OpenShift security apis to scheme
 	if err := securityv1.Install(mgr.GetScheme()); err != nil {
+		log.Error(err, "")
+		os.Exit(1)
+	}
+
+	// Need this for the CustomResourceDefinition Kind
+	if err := apiextensions.AddToScheme(mgr.GetScheme()); err != nil {
 		log.Error(err, "")
 		os.Exit(1)
 	}

--- a/deploy/cluster_role.yaml
+++ b/deploy/cluster_role.yaml
@@ -62,3 +62,10 @@ rules:
   - securitycontextconstraints
   verbs:
   - '*'
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - watch

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
 	k8s.io/api v0.0.0
+	k8s.io/apiextensions-apiserver v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kubernetes v1.16.2

--- a/pkg/apis/awsefs/v1alpha1/owner.go
+++ b/pkg/apis/awsefs/v1alpha1/owner.go
@@ -1,0 +1,16 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CreateOwnerReference constructs an OwnerReference from this SharedVolume, for use in the list of
+// OwnerReferences of another object.
+func (sv *SharedVolume) CreateOwnerReference() metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: sv.APIVersion,
+		Kind:       sv.Kind,
+		Name:       sv.Name,
+		UID:        sv.UID,
+	}
+}

--- a/pkg/controller/sharedvolume/pv_ensurable.go
+++ b/pkg/controller/sharedvolume/pv_ensurable.go
@@ -55,6 +55,10 @@ func pvDefinition(sharedVolume *awsefsv1alpha1.SharedVolume) *corev1.PersistentV
 	pv := &corev1.PersistentVolume{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: pvNameForSharedVolume(sharedVolume),
+			// Make the PV owned by the SV so it gets deleted automatically
+			OwnerReferences: []metav1.OwnerReference{
+				sharedVolume.CreateOwnerReference(),
+			},
 		},
 		Spec: corev1.PersistentVolumeSpec{
 			Capacity: corev1.ResourceList{

--- a/pkg/controller/sharedvolume/pvc_ensurable.go
+++ b/pkg/controller/sharedvolume/pvc_ensurable.go
@@ -57,6 +57,10 @@ func pvcDefinition(sharedVolume *awsefsv1alpha1.SharedVolume) *corev1.Persistent
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      nsname.Name,
 			Namespace: nsname.Namespace,
+			// Make the PVC owned by the SV so it gets deleted automatically
+			OwnerReferences: []metav1.OwnerReference{
+				sharedVolume.CreateOwnerReference(),
+			},
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteMany},

--- a/pkg/controller/sharedvolume/testdata/persistentvolume.yaml
+++ b/pkg/controller/sharedvolume/testdata/persistentvolume.yaml
@@ -3,6 +3,8 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: pv-project1-my-shared-volume
+  ownerReferences:
+    - name: my-shared-volume
 spec:
   capacity:
     storage: 1Gi

--- a/pkg/controller/sharedvolume/testdata/pvc.yaml
+++ b/pkg/controller/sharedvolume/testdata/pvc.yaml
@@ -4,6 +4,8 @@ kind: PersistentVolumeClaim
 metadata:
   name: pvc-my-shared-volume
   namespace: project1
+  ownerReferences:
+    - name: my-shared-volume
 spec:
   accessModes:
     - ReadWriteMany

--- a/pkg/controller/statics/statics.go
+++ b/pkg/controller/statics/statics.go
@@ -93,6 +93,7 @@ func init() {
 	loadDefTemplate(scDef, "storageclass.yaml")
 	StorageClassName = scDef.Name
 
+	// NOTE(efried): We can't SetOwner() yet because we don't have the CRD at this stage.
 	staticResources = []util.Ensurable{
 		&util.EnsurableImpl{
 			ObjType:        &corev1.ServiceAccount{},

--- a/pkg/fixtures/zz_generated_mock_crclient.go
+++ b/pkg/fixtures/zz_generated_mock_crclient.go
@@ -13,30 +13,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method
+// Create mocks base method.
 func (m *MockClient) Create(arg0 context.Context, arg1 runtime.Object, arg2 ...client.CreateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -48,14 +48,14 @@ func (m *MockClient) Create(arg0 context.Context, arg1 runtime.Object, arg2 ...c
 	return ret0
 }
 
-// Create indicates an expected call of Create
+// Create indicates an expected call of Create.
 func (mr *MockClientMockRecorder) Create(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), varargs...)
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockClient) Delete(arg0 context.Context, arg1 runtime.Object, arg2 ...client.DeleteOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -67,14 +67,14 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 runtime.Object, arg2 ...c
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockClientMockRecorder) Delete(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
 }
 
-// DeleteAllOf mocks base method
+// DeleteAllOf mocks base method.
 func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 runtime.Object, arg2 ...client.DeleteAllOfOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -86,14 +86,14 @@ func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 runtime.Object, arg2
 	return ret0
 }
 
-// DeleteAllOf indicates an expected call of DeleteAllOf
+// DeleteAllOf indicates an expected call of DeleteAllOf.
 func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOf", reflect.TypeOf((*MockClient)(nil).DeleteAllOf), varargs...)
 }
 
-// Get mocks base method
+// Get mocks base method.
 func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 runtime.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
@@ -101,13 +101,13 @@ func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 r
 	return ret0
 }
 
-// Get indicates an expected call of Get
+// Get indicates an expected call of Get.
 func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1, arg2)
 }
 
-// List mocks base method
+// List mocks base method.
 func (m *MockClient) List(arg0 context.Context, arg1 runtime.Object, arg2 ...client.ListOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -119,14 +119,14 @@ func (m *MockClient) List(arg0 context.Context, arg1 runtime.Object, arg2 ...cli
 	return ret0
 }
 
-// List indicates an expected call of List
+// List indicates an expected call of List.
 func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
-// Patch mocks base method
+// Patch mocks base method.
 func (m *MockClient) Patch(arg0 context.Context, arg1 runtime.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -138,14 +138,14 @@ func (m *MockClient) Patch(arg0 context.Context, arg1 runtime.Object, arg2 clien
 	return ret0
 }
 
-// Patch indicates an expected call of Patch
+// Patch indicates an expected call of Patch.
 func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), varargs...)
 }
 
-// Status mocks base method
+// Status mocks base method.
 func (m *MockClient) Status() client.StatusWriter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
@@ -153,13 +153,13 @@ func (m *MockClient) Status() client.StatusWriter {
 	return ret0
 }
 
-// Status indicates an expected call of Status
+// Status indicates an expected call of Status.
 func (mr *MockClientMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockClient)(nil).Status))
 }
 
-// Update mocks base method
+// Update mocks base method.
 func (m *MockClient) Update(arg0 context.Context, arg1 runtime.Object, arg2 ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -171,7 +171,7 @@ func (m *MockClient) Update(arg0 context.Context, arg1 runtime.Object, arg2 ...c
 	return ret0
 }
 
-// Update indicates an expected call of Update
+// Update indicates an expected call of Update.
 func (mr *MockClientMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/pkg/fixtures/zz_generated_mock_ensurable.go
+++ b/pkg/fixtures/zz_generated_mock_ensurable.go
@@ -7,36 +7,37 @@ package fixtures
 import (
 	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	types "k8s.io/apimachinery/pkg/types"
 	reflect "reflect"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockEnsurable is a mock of Ensurable interface
+// MockEnsurable is a mock of Ensurable interface.
 type MockEnsurable struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnsurableMockRecorder
 }
 
-// MockEnsurableMockRecorder is the mock recorder for MockEnsurable
+// MockEnsurableMockRecorder is the mock recorder for MockEnsurable.
 type MockEnsurableMockRecorder struct {
 	mock *MockEnsurable
 }
 
-// NewMockEnsurable creates a new mock instance
+// NewMockEnsurable creates a new mock instance.
 func NewMockEnsurable(ctrl *gomock.Controller) *MockEnsurable {
 	mock := &MockEnsurable{ctrl: ctrl}
 	mock.recorder = &MockEnsurableMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockEnsurable) EXPECT() *MockEnsurableMockRecorder {
 	return m.recorder
 }
 
-// GetType mocks base method
+// GetType mocks base method.
 func (m *MockEnsurable) GetType() runtime.Object {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetType")
@@ -44,13 +45,13 @@ func (m *MockEnsurable) GetType() runtime.Object {
 	return ret0
 }
 
-// GetType indicates an expected call of GetType
+// GetType indicates an expected call of GetType.
 func (mr *MockEnsurableMockRecorder) GetType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockEnsurable)(nil).GetType))
 }
 
-// GetNamespacedName mocks base method
+// GetNamespacedName mocks base method.
 func (m *MockEnsurable) GetNamespacedName() types.NamespacedName {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespacedName")
@@ -58,13 +59,25 @@ func (m *MockEnsurable) GetNamespacedName() types.NamespacedName {
 	return ret0
 }
 
-// GetNamespacedName indicates an expected call of GetNamespacedName
+// GetNamespacedName indicates an expected call of GetNamespacedName.
 func (mr *MockEnsurableMockRecorder) GetNamespacedName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespacedName", reflect.TypeOf((*MockEnsurable)(nil).GetNamespacedName))
 }
 
-// Ensure mocks base method
+// SetOwner mocks base method.
+func (m *MockEnsurable) SetOwner(arg0 *v1.OwnerReference) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetOwner", arg0)
+}
+
+// SetOwner indicates an expected call of SetOwner.
+func (mr *MockEnsurableMockRecorder) SetOwner(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOwner", reflect.TypeOf((*MockEnsurable)(nil).SetOwner), arg0)
+}
+
+// Ensure mocks base method.
 func (m *MockEnsurable) Ensure(arg0 logr.Logger, arg1 client.Client) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ensure", arg0, arg1)
@@ -72,13 +85,13 @@ func (m *MockEnsurable) Ensure(arg0 logr.Logger, arg1 client.Client) error {
 	return ret0
 }
 
-// Ensure indicates an expected call of Ensure
+// Ensure indicates an expected call of Ensure.
 func (mr *MockEnsurableMockRecorder) Ensure(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockEnsurable)(nil).Ensure), arg0, arg1)
 }
 
-// Delete mocks base method
+// Delete mocks base method.
 func (m *MockEnsurable) Delete(arg0 logr.Logger, arg1 client.Client) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
@@ -86,7 +99,7 @@ func (m *MockEnsurable) Delete(arg0 logr.Logger, arg1 client.Client) error {
 	return ret0
 }
 
-// Delete indicates an expected call of Delete
+// Delete indicates an expected call of Delete.
 func (mr *MockEnsurableMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEnsurable)(nil).Delete), arg0, arg1)

--- a/pkg/fixtures/zz_generated_mock_logr.go
+++ b/pkg/fixtures/zz_generated_mock_logr.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockLogger is a mock of Logger interface
+// MockLogger is a mock of Logger interface.
 type MockLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerMockRecorder
 }
 
-// MockLoggerMockRecorder is the mock recorder for MockLogger
+// MockLoggerMockRecorder is the mock recorder for MockLogger.
 type MockLoggerMockRecorder struct {
 	mock *MockLogger
 }
 
-// NewMockLogger creates a new mock instance
+// NewMockLogger creates a new mock instance.
 func NewMockLogger(ctrl *gomock.Controller) *MockLogger {
 	mock := &MockLogger{ctrl: ctrl}
 	mock.recorder = &MockLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
-// Enabled mocks base method
+// Enabled mocks base method.
 func (m *MockLogger) Enabled() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Enabled")
@@ -41,13 +41,13 @@ func (m *MockLogger) Enabled() bool {
 	return ret0
 }
 
-// Enabled indicates an expected call of Enabled
+// Enabled indicates an expected call of Enabled.
 func (mr *MockLoggerMockRecorder) Enabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enabled", reflect.TypeOf((*MockLogger)(nil).Enabled))
 }
 
-// Error mocks base method
+// Error mocks base method.
 func (m *MockLogger) Error(arg0 error, arg1 string, arg2 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -57,14 +57,14 @@ func (m *MockLogger) Error(arg0 error, arg1 string, arg2 ...interface{}) {
 	m.ctrl.Call(m, "Error", varargs...)
 }
 
-// Error indicates an expected call of Error
+// Error indicates an expected call of Error.
 func (mr *MockLoggerMockRecorder) Error(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockLogger)(nil).Error), varargs...)
 }
 
-// Info mocks base method
+// Info mocks base method.
 func (m *MockLogger) Info(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -74,14 +74,14 @@ func (m *MockLogger) Info(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Info", varargs...)
 }
 
-// Info indicates an expected call of Info
+// Info indicates an expected call of Info.
 func (mr *MockLoggerMockRecorder) Info(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLogger)(nil).Info), varargs...)
 }
 
-// V mocks base method
+// V mocks base method.
 func (m *MockLogger) V(arg0 int) logr.InfoLogger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "V", arg0)
@@ -89,13 +89,13 @@ func (m *MockLogger) V(arg0 int) logr.InfoLogger {
 	return ret0
 }
 
-// V indicates an expected call of V
+// V indicates an expected call of V.
 func (mr *MockLoggerMockRecorder) V(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V", reflect.TypeOf((*MockLogger)(nil).V), arg0)
 }
 
-// WithName mocks base method
+// WithName mocks base method.
 func (m *MockLogger) WithName(arg0 string) logr.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithName", arg0)
@@ -103,13 +103,13 @@ func (m *MockLogger) WithName(arg0 string) logr.Logger {
 	return ret0
 }
 
-// WithName indicates an expected call of WithName
+// WithName indicates an expected call of WithName.
 func (mr *MockLoggerMockRecorder) WithName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithName", reflect.TypeOf((*MockLogger)(nil).WithName), arg0)
 }
 
-// WithValues mocks base method
+// WithValues mocks base method.
 func (m *MockLogger) WithValues(arg0 ...interface{}) logr.Logger {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -121,7 +121,7 @@ func (m *MockLogger) WithValues(arg0 ...interface{}) logr.Logger {
 	return ret0
 }
 
-// WithValues indicates an expected call of WithValues
+// WithValues indicates an expected call of WithValues.
 func (mr *MockLoggerMockRecorder) WithValues(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithValues", reflect.TypeOf((*MockLogger)(nil).WithValues), arg0...)

--- a/pkg/test/client.go
+++ b/pkg/test/client.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// FakeClientWithCustomErrors overrides some of the fake client's methods, allowing them to (not
+// actually run and) throw specific errors. Use it like this:
+//   realFakeClient := NewFakeClient(...)
+//   c := FakeClientWithCustomErrors{
+//       Client: realFakeClient,
+//       DeleteBehavior: []error{nil, fmt.Errorf("Error on the second call"), nil}
+//       UpdateBehavior: []error(fmt.Errorf("Error on the first call"))
+//   }
+//   c.Delete(...) // runs the real fake Delete
+//   c.Delete(...) // skips the real fake Delete and returns the first error
+//   c.Delete(...) // runs the real fake Delete
+//   c.Delete(...) // runs the real fake Delete, even though we ran off the end of the array
+//   c.Update(...) // returns the error
+//   c.Get(...)    // runs the real fake Get, because no overrides
+type FakeClientWithCustomErrors struct {
+	// The "Real" fake client
+	crclient.Client
+	// Entries in this list affect each successive call to Get(). Using `nil` causes the "real"
+	// Get to be called. Using a non-nil error causes the "real" Get to be skipped, and that
+	// error to be returned instead.
+	GetBehavior []error
+	// Private tracker of calls to Get, used to determine which GetBehavior to use.
+	numGetCalls int
+	// Ditto Delete
+	DeleteBehavior []error
+	// Private tracker of calls to Delete, used to determine which DeleteBehavior to use.
+	numDeleteCalls int
+	// Ditto Update
+	UpdateBehavior []error
+	// Private tracker of calls to Update, used to determine which UpdateBehavior to use.
+	numUpdateCalls int
+	// TODO(efried): Add the other methods. Propose upstream.
+}
+
+func clientOverride(behavior []error, numCalls int) error {
+	if len(behavior) > numCalls {
+		return behavior[numCalls] // which might be nil
+	}
+	// If we ran off the end, assume default behavior
+	return nil
+}
+
+// Get overrides the fake client's Get, conditionally bypassing it and returning an error instead.
+func (f *FakeClientWithCustomErrors) Get(ctx context.Context, key crclient.ObjectKey, obj runtime.Object) error {
+	// Always increment the call count, but not until we're done.
+	defer func() { f.numGetCalls++ }()
+	if err := clientOverride(f.GetBehavior, f.numGetCalls); err != nil {
+		return err
+	}
+	// Otherwise run the real Get
+	return f.Client.Get(ctx, key, obj)
+}
+
+// Delete overrides the fake client's Delete, conditionally bypassing it and returning an error instead.
+func (f *FakeClientWithCustomErrors) Delete(ctx context.Context, obj runtime.Object, opts ...crclient.DeleteOption) error {
+	// Always increment the call count, but not until we're done.
+	defer func() { f.numDeleteCalls++ }()
+	if err := clientOverride(f.DeleteBehavior, f.numDeleteCalls); err != nil {
+		return err
+	}
+	// Otherwise run the real Delete
+	return f.Client.Delete(ctx, obj, opts...)
+}
+
+// Update overrides the fake client's Update, conditionally bypassing it and returning an error instead.
+func (f *FakeClientWithCustomErrors) Update(ctx context.Context, obj runtime.Object, opts ...crclient.UpdateOption) error {
+	// Always increment the call count, but not until we're done.
+	defer func() { f.numUpdateCalls++ }()
+	if err := clientOverride(f.UpdateBehavior, f.numUpdateCalls); err != nil {
+		return err
+	}
+	// Otherwise run the real Update
+	return f.Client.Update(ctx, obj, opts...)
+}

--- a/pkg/util/owner.go
+++ b/pkg/util/owner.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// AsOwner constructs an OwnerReference from the provided obj.
+func AsOwner(obj runtime.Object) *metav1.OwnerReference {
+	apiVersion, kind := obj.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
+	mobj := obj.(metav1.Object)
+	return &metav1.OwnerReference{
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Name:       mobj.GetName(),
+		UID:        mobj.GetUID(),
+	}
+}


### PR DESCRIPTION
By adding an OwnerReference to the SharedVolume to the PV and PVC it
creates, kubernetes handles their deletion for us. This allows us to rip
out a big chain of code, including:

- Deletion logic for PV and PVC Ensurables.
- The whole Delete method of the Ensurable interface, since it was the
only thing using the above.
- The entire SharedVolume finalizer and associated handling, since the
above was its only purpose.

Jira: [OSD-4083](https://issues.redhat.com/browse/OSD-4083) (sort of)