### PR TITLE
Change dnsPolicy to ClusterFirstWithHostNet for EFS DNS resolution under VPC peering

### DIFF
--- a/pkg/controller/statics/defs/daemonset.yaml
+++ b/pkg/controller/statics/defs/daemonset.yaml
@@ -26,6 +26,7 @@ spec:
         # NOTE: This will hit infra nodes as well.
         node-role.kubernetes.io/worker: ''
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: Exists
       containers:

--- a/pkg/controller/statics/zz_generated_defs.go
+++ b/pkg/controller/statics/zz_generated_defs.go
@@ -112,6 +112,7 @@ spec:
         # NOTE: This will hit infra nodes as well.
         node-role.kubernetes.io/worker: ''
       hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
       tolerations:
         - operator: Exists
       containers:

--- a/pkg/fixtures/zz_generated_mock_crclient.go
+++ b/pkg/fixtures/zz_generated_mock_crclient.go
@@ -13,30 +13,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockClient) Create(arg0 context.Context, arg1 runtime.Object, arg2 ...client.CreateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -48,14 +48,14 @@ func (m *MockClient) Create(arg0 context.Context, arg1 runtime.Object, arg2 ...c
 	return ret0
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockClientMockRecorder) Create(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockClient)(nil).Create), varargs...)
 }
 
-// Delete mocks base method.
+// Delete mocks base method
 func (m *MockClient) Delete(arg0 context.Context, arg1 runtime.Object, arg2 ...client.DeleteOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -67,14 +67,14 @@ func (m *MockClient) Delete(arg0 context.Context, arg1 runtime.Object, arg2 ...c
 	return ret0
 }
 
-// Delete indicates an expected call of Delete.
+// Delete indicates an expected call of Delete
 func (mr *MockClientMockRecorder) Delete(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
 }
 
-// DeleteAllOf mocks base method.
+// DeleteAllOf mocks base method
 func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 runtime.Object, arg2 ...client.DeleteAllOfOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -86,14 +86,14 @@ func (m *MockClient) DeleteAllOf(arg0 context.Context, arg1 runtime.Object, arg2
 	return ret0
 }
 
-// DeleteAllOf indicates an expected call of DeleteAllOf.
+// DeleteAllOf indicates an expected call of DeleteAllOf
 func (mr *MockClientMockRecorder) DeleteAllOf(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAllOf", reflect.TypeOf((*MockClient)(nil).DeleteAllOf), varargs...)
 }
 
-// Get mocks base method.
+// Get mocks base method
 func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 runtime.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
@@ -101,13 +101,13 @@ func (m *MockClient) Get(arg0 context.Context, arg1 types.NamespacedName, arg2 r
 	return ret0
 }
 
-// Get indicates an expected call of Get.
+// Get indicates an expected call of Get
 func (mr *MockClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), arg0, arg1, arg2)
 }
 
-// List mocks base method.
+// List mocks base method
 func (m *MockClient) List(arg0 context.Context, arg1 runtime.Object, arg2 ...client.ListOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -119,14 +119,14 @@ func (m *MockClient) List(arg0 context.Context, arg1 runtime.Object, arg2 ...cli
 	return ret0
 }
 
-// List indicates an expected call of List.
+// List indicates an expected call of List
 func (mr *MockClientMockRecorder) List(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockClient)(nil).List), varargs...)
 }
 
-// Patch mocks base method.
+// Patch mocks base method
 func (m *MockClient) Patch(arg0 context.Context, arg1 runtime.Object, arg2 client.Patch, arg3 ...client.PatchOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
@@ -138,14 +138,14 @@ func (m *MockClient) Patch(arg0 context.Context, arg1 runtime.Object, arg2 clien
 	return ret0
 }
 
-// Patch indicates an expected call of Patch.
+// Patch indicates an expected call of Patch
 func (mr *MockClientMockRecorder) Patch(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Patch", reflect.TypeOf((*MockClient)(nil).Patch), varargs...)
 }
 
-// Status mocks base method.
+// Status mocks base method
 func (m *MockClient) Status() client.StatusWriter {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Status")
@@ -153,13 +153,13 @@ func (m *MockClient) Status() client.StatusWriter {
 	return ret0
 }
 
-// Status indicates an expected call of Status.
+// Status indicates an expected call of Status
 func (mr *MockClientMockRecorder) Status() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Status", reflect.TypeOf((*MockClient)(nil).Status))
 }
 
-// Update mocks base method.
+// Update mocks base method
 func (m *MockClient) Update(arg0 context.Context, arg1 runtime.Object, arg2 ...client.UpdateOption) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -171,7 +171,7 @@ func (m *MockClient) Update(arg0 context.Context, arg1 runtime.Object, arg2 ...c
 	return ret0
 }
 
-// Update indicates an expected call of Update.
+// Update indicates an expected call of Update
 func (mr *MockClientMockRecorder) Update(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)

--- a/pkg/fixtures/zz_generated_mock_ensurable.go
+++ b/pkg/fixtures/zz_generated_mock_ensurable.go
@@ -14,30 +14,30 @@ import (
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MockEnsurable is a mock of Ensurable interface.
+// MockEnsurable is a mock of Ensurable interface
 type MockEnsurable struct {
 	ctrl     *gomock.Controller
 	recorder *MockEnsurableMockRecorder
 }
 
-// MockEnsurableMockRecorder is the mock recorder for MockEnsurable.
+// MockEnsurableMockRecorder is the mock recorder for MockEnsurable
 type MockEnsurableMockRecorder struct {
 	mock *MockEnsurable
 }
 
-// NewMockEnsurable creates a new mock instance.
+// NewMockEnsurable creates a new mock instance
 func NewMockEnsurable(ctrl *gomock.Controller) *MockEnsurable {
 	mock := &MockEnsurable{ctrl: ctrl}
 	mock.recorder = &MockEnsurableMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockEnsurable) EXPECT() *MockEnsurableMockRecorder {
 	return m.recorder
 }
 
-// GetType mocks base method.
+// GetType mocks base method
 func (m *MockEnsurable) GetType() runtime.Object {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetType")
@@ -45,13 +45,13 @@ func (m *MockEnsurable) GetType() runtime.Object {
 	return ret0
 }
 
-// GetType indicates an expected call of GetType.
+// GetType indicates an expected call of GetType
 func (mr *MockEnsurableMockRecorder) GetType() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockEnsurable)(nil).GetType))
 }
 
-// GetNamespacedName mocks base method.
+// GetNamespacedName mocks base method
 func (m *MockEnsurable) GetNamespacedName() types.NamespacedName {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetNamespacedName")
@@ -59,25 +59,25 @@ func (m *MockEnsurable) GetNamespacedName() types.NamespacedName {
 	return ret0
 }
 
-// GetNamespacedName indicates an expected call of GetNamespacedName.
+// GetNamespacedName indicates an expected call of GetNamespacedName
 func (mr *MockEnsurableMockRecorder) GetNamespacedName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespacedName", reflect.TypeOf((*MockEnsurable)(nil).GetNamespacedName))
 }
 
-// SetOwner mocks base method.
+// SetOwner mocks base method
 func (m *MockEnsurable) SetOwner(arg0 *v1.OwnerReference) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetOwner", arg0)
 }
 
-// SetOwner indicates an expected call of SetOwner.
+// SetOwner indicates an expected call of SetOwner
 func (mr *MockEnsurableMockRecorder) SetOwner(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOwner", reflect.TypeOf((*MockEnsurable)(nil).SetOwner), arg0)
 }
 
-// Ensure mocks base method.
+// Ensure mocks base method
 func (m *MockEnsurable) Ensure(arg0 logr.Logger, arg1 client.Client) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Ensure", arg0, arg1)
@@ -85,13 +85,13 @@ func (m *MockEnsurable) Ensure(arg0 logr.Logger, arg1 client.Client) error {
 	return ret0
 }
 
-// Ensure indicates an expected call of Ensure.
+// Ensure indicates an expected call of Ensure
 func (mr *MockEnsurableMockRecorder) Ensure(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Ensure", reflect.TypeOf((*MockEnsurable)(nil).Ensure), arg0, arg1)
 }
 
-// Delete mocks base method.
+// Delete mocks base method
 func (m *MockEnsurable) Delete(arg0 logr.Logger, arg1 client.Client) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
@@ -99,7 +99,7 @@ func (m *MockEnsurable) Delete(arg0 logr.Logger, arg1 client.Client) error {
 	return ret0
 }
 
-// Delete indicates an expected call of Delete.
+// Delete indicates an expected call of Delete
 func (mr *MockEnsurableMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockEnsurable)(nil).Delete), arg0, arg1)

--- a/pkg/fixtures/zz_generated_mock_logr.go
+++ b/pkg/fixtures/zz_generated_mock_logr.go
@@ -10,30 +10,30 @@ import (
 	reflect "reflect"
 )
 
-// MockLogger is a mock of Logger interface.
+// MockLogger is a mock of Logger interface
 type MockLogger struct {
 	ctrl     *gomock.Controller
 	recorder *MockLoggerMockRecorder
 }
 
-// MockLoggerMockRecorder is the mock recorder for MockLogger.
+// MockLoggerMockRecorder is the mock recorder for MockLogger
 type MockLoggerMockRecorder struct {
 	mock *MockLogger
 }
 
-// NewMockLogger creates a new mock instance.
+// NewMockLogger creates a new mock instance
 func NewMockLogger(ctrl *gomock.Controller) *MockLogger {
 	mock := &MockLogger{ctrl: ctrl}
 	mock.recorder = &MockLoggerMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockLogger) EXPECT() *MockLoggerMockRecorder {
 	return m.recorder
 }
 
-// Enabled mocks base method.
+// Enabled mocks base method
 func (m *MockLogger) Enabled() bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Enabled")
@@ -41,13 +41,13 @@ func (m *MockLogger) Enabled() bool {
 	return ret0
 }
 
-// Enabled indicates an expected call of Enabled.
+// Enabled indicates an expected call of Enabled
 func (mr *MockLoggerMockRecorder) Enabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Enabled", reflect.TypeOf((*MockLogger)(nil).Enabled))
 }
 
-// Error mocks base method.
+// Error mocks base method
 func (m *MockLogger) Error(arg0 error, arg1 string, arg2 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1}
@@ -57,14 +57,14 @@ func (m *MockLogger) Error(arg0 error, arg1 string, arg2 ...interface{}) {
 	m.ctrl.Call(m, "Error", varargs...)
 }
 
-// Error indicates an expected call of Error.
+// Error indicates an expected call of Error
 func (mr *MockLoggerMockRecorder) Error(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Error", reflect.TypeOf((*MockLogger)(nil).Error), varargs...)
 }
 
-// Info mocks base method.
+// Info mocks base method
 func (m *MockLogger) Info(arg0 string, arg1 ...interface{}) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
@@ -74,14 +74,14 @@ func (m *MockLogger) Info(arg0 string, arg1 ...interface{}) {
 	m.ctrl.Call(m, "Info", varargs...)
 }
 
-// Info indicates an expected call of Info.
+// Info indicates an expected call of Info
 func (mr *MockLoggerMockRecorder) Info(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockLogger)(nil).Info), varargs...)
 }
 
-// V mocks base method.
+// V mocks base method
 func (m *MockLogger) V(arg0 int) logr.InfoLogger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "V", arg0)
@@ -89,13 +89,13 @@ func (m *MockLogger) V(arg0 int) logr.InfoLogger {
 	return ret0
 }
 
-// V indicates an expected call of V.
+// V indicates an expected call of V
 func (mr *MockLoggerMockRecorder) V(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "V", reflect.TypeOf((*MockLogger)(nil).V), arg0)
 }
 
-// WithName mocks base method.
+// WithName mocks base method
 func (m *MockLogger) WithName(arg0 string) logr.Logger {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithName", arg0)
@@ -103,13 +103,13 @@ func (m *MockLogger) WithName(arg0 string) logr.Logger {
 	return ret0
 }
 
-// WithName indicates an expected call of WithName.
+// WithName indicates an expected call of WithName
 func (mr *MockLoggerMockRecorder) WithName(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithName", reflect.TypeOf((*MockLogger)(nil).WithName), arg0)
 }
 
-// WithValues mocks base method.
+// WithValues mocks base method
 func (m *MockLogger) WithValues(arg0 ...interface{}) logr.Logger {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{}
@@ -121,7 +121,7 @@ func (m *MockLogger) WithValues(arg0 ...interface{}) logr.Logger {
 	return ret0
 }
 
-// WithValues indicates an expected call of WithValues.
+// WithValues indicates an expected call of WithValues
 func (mr *MockLoggerMockRecorder) WithValues(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithValues", reflect.TypeOf((*MockLogger)(nil).WithValues), arg0...)


### PR DESCRIPTION
* Description: 
  As changing dnsPolicy to `ClusterFirstWithHostNet`, EFS Operator can refer the custom EFS DNS records without much modifications through DNS Operator. To implements `hostAliases` on the DaemonSet, it would modify much changes at the reconciling loop logic, but it's simple and we can get the same result through a little bit changes.

* More Reference: https://github.com/kubernetes-sigs/aws-efs-csi-driver/issues/240

* More informations:
  - [Pod's DNS Policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy)
  - In my short test, I could not find out odd behaviours. 

* Before changing dnsPolicy(ClusterFirst), DaemonSet refer host `/etc/resolv.conf`. It will be causes not to use custom DNS records using DNS Operator. And EFS DNS name cannot resolve under VPC peering.
```console
$ oc rsh efs-csi-node-66hnr cat /etc/resolv.conf
Defaulting container name to efs-plugin.
Use 'oc describe pod/efs-csi-node-66hnr -n openshift-operators' to see all of the containers in this pod.
search ap-northeast-1.compute.internal
nameserver 10.0.0.2
```
* After changing dnsPolicy(ClusterFirstWithHostNet), the EFS DNS name can resolve and pod can mount SharedVolume under VPC peering using custom records through DNS Operator
```console
// DNS operator
$ oc edit dns.operator/default
:
spec: 
  servers:
  - name: efs-nameserver
    zones:
    - efs.ap-northeast-1.amazonaws.com
    forwardPlugin:
      upstreams:
        - 10.0.124.102

// Operator's SCC is chosen correctly even though dnsPolicy was changed.
$ oc get pod efs-csi-node-pm2m7 -o yaml | grep scc
    openshift.io/scc: efs-csi-scc

// the resolv.conf are changed pod namespace ones.
$ oc rsh efs-csi-node-pm2m7 cat /etc/resolv.conf
Defaulting container name to efs-plugin.
Use 'oc describe pod/efs-csi-node-pm2m7 -n openshift-operators' to see all of the containers in this pod.
search openshift-operators.svc.cluster.local svc.cluster.local cluster.local ap-northeast-1.compute.internal
nameserver 172.30.0.10
options ndots:5

// Yeah, we can get the custom record through DNS Operator
$ oc rsh efs-csi-node-fn756 curl -v fs-ec8395cd.efs.ap-northeast-1.amazonaws.com
Defaulting container name to efs-plugin.
Use 'oc describe pod/efs-csi-node-fn756 -n openshift-operators' to see all of the containers in this pod.
* Rebuilt URL to: fs-ec8395cd.efs.ap-northeast-1.amazonaws.com/
*   Trying 10.24.10.173...                                        <--- EFS DNS name can be resolved through DNS Operator.
* TCP_NODELAY set
```