### PR TITLE
Revert "Remove efried per Leaver process"

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,7 +3,9 @@ reviewers:
 - dustman9000
 - jharrington22
 approvers:
+- 2uasimojo
 - dustman9000
 - jharrington22
 maintainers:
+- 2uasimojo
 - jharrington22 


### PR DESCRIPTION
Reverts openshift/aws-efs-operator#37

Upon further discussion with @jharrington22 and @cblecker we agreed that @2uasimojo should remain as an Approver and Maintainer on this repo because it's a "community supported" offering, not officially supported or controlled by SRE-P as part of the OSD/ROSA offering. 