### PR TITLE
Update k8s storage CSI Driver API to v1

### DIFF
--- a/pkg/controller/statics/defs/csidriver.yaml
+++ b/pkg/controller/statics/defs/csidriver.yaml
@@ -1,6 +1,6 @@
 # Source: https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/51d19a433dcfc47fbb7b7a0e1c8ff6ab98ce87e9/deploy/kubernetes/base/csidriver.yaml
 kind: CSIDriver
-apiVersion: storage.k8s.io/v1beta1
+apiVersion: storage.k8s.io/v1
 metadata:
   name: efs.csi.aws.com
 spec:

--- a/pkg/controller/statics/statics.go
+++ b/pkg/controller/statics/statics.go
@@ -18,7 +18,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/clientcmd"
@@ -85,7 +84,7 @@ func init() {
 	dsDef.SetNamespace(namespaceName)
 	daemonSetName = dsDef.Name
 
-	csiDef := &storagev1beta1.CSIDriver{}
+	csiDef := &storagev1.CSIDriver{}
 	loadDefTemplate(csiDef, "csidriver.yaml")
 	CSIDriverName = csiDef.Name
 
@@ -115,7 +114,7 @@ func init() {
 			EqualFunc:      daemonSetEqual,
 		},
 		&util.EnsurableImpl{
-			ObjType:        &storagev1beta1.CSIDriver{},
+			ObjType:        &storagev1.CSIDriver{},
 			NamespacedName: getNSName(csiDef),
 			Definition:     csiDef,
 			EqualFunc:      csiDriverEqual,
@@ -211,8 +210,8 @@ func EnsureStatics(log logr.Logger, client crclient.Client) error {
 
 func csiDriverEqual(local, server runtime.Object) bool {
 	return reflect.DeepEqual(
-		local.(*storagev1beta1.CSIDriver).Spec,
-		server.(*storagev1beta1.CSIDriver).Spec,
+		local.(*storagev1.CSIDriver).Spec,
+		server.(*storagev1.CSIDriver).Spec,
 	)
 }
 

--- a/pkg/controller/statics/statics_helpers_for_test.go
+++ b/pkg/controller/statics/statics_helpers_for_test.go
@@ -13,7 +13,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -62,7 +61,7 @@ func checkStatics(t *testing.T, client crclient.Client) map[string]runtime.Objec
 		},
 		{
 			"CSIDriver",
-			&storagev1beta1.CSIDriver{},
+			&storagev1.CSIDriver{},
 			types.NamespacedName{Name: CSIDriverName},
 		},
 		{

--- a/pkg/controller/statics/statics_test.go
+++ b/pkg/controller/statics/statics_test.go
@@ -12,7 +12,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	storagev1beta1 "k8s.io/api/storage/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -160,7 +159,7 @@ func Test_static_GetType(t *testing.T) {
 	}
 	// CSIDriver
 	nsn = types.NamespacedName{Name: CSIDriverName}
-	if _, ok := findStatic(nsn).GetType().(*storagev1beta1.CSIDriver); !ok {
+	if _, ok := findStatic(nsn).GetType().(*storagev1.CSIDriver); !ok {
 		t.Fatal("GetType() returned the wrong type for CSIDriver static resource.")
 	}
 	// StorageClass
@@ -241,7 +240,7 @@ func Test_storageClassEqual(t *testing.T) {
 }
 
 func Test_csiDriverEqual(t *testing.T) {
-	cd1 := staticResourceMap[CSIDriverName].(*util.EnsurableImpl).Definition.(*storagev1beta1.CSIDriver)
+	cd1 := staticResourceMap[CSIDriverName].(*util.EnsurableImpl).Definition.(*storagev1.CSIDriver)
 	cd2 := cd1.DeepCopy()
 
 	if !csiDriverEqual(cd1, cd1) {


### PR DESCRIPTION
Update k8s storage CSI Driver API to v1

New storage CSI driver required k8s deps upgrade to at least 0.18.0 which was completed in #43.

Tested operator new CSI driver version on OCP 4.9.6

```
oc get clusterversion
NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
version   4.9.6     True        False         166m    Cluster version is 4.9.6
```

Operator logs for verification

```
{"level":"info","ts":1639782530.9271128,"logger":"cmd","msg":"Operator Version: 0.0.1"}
{"level":"info","ts":1639782530.9272738,"logger":"cmd","msg":"Go Version: go1.16"}                                                                                                  
{"level":"info","ts":1639782530.9273074,"logger":"cmd","msg":"Go OS/Arch: linux/amd64"}                                                                                             {"level":"info","ts":1639782530.9273217,"logger":"cmd","msg":"Version of operator-sdk: v0.18.2"}                                                                                    
{"level":"info","ts":1639782530.9278007,"logger":"leader","msg":"Trying to become the leader."}                                                                                     I1217 23:08:51.978592       1 request.go:645] Throttling request took 1.039338026s, request: GET:https://172.30.0.1:443/apis/config.openshift.io/v1?timeout=32s                     
{"level":"info","ts":1639782533.6922016,"logger":"leader","msg":"No pre-existing lock was found."}                                                                                  
{"level":"info","ts":1639782533.698035,"logger":"leader","msg":"Became the leader."}                                                                                                
{"level":"info","ts":1639782536.45349,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"0.0.0.0:8383"}                                     {"level":"info","ts":1639782536.4538062,"logger":"cmd","msg":"Registering Components."}                                                                                             
{"level":"info","ts":1639782539.2111015,"logger":"cmd","msg":"Found. Checking whether update is needed.","resource":{"namespace":"openshift-operators","name":"efs-csi-sa"}}        {"level":"info","ts":1639782539.2111475,"logger":"cmd","msg":"No update needed."}                                                                                                   
{"level":"info","ts":1639782539.2151961,"logger":"cmd","msg":"Found. Checking whether update is needed.","resource":{"name":"efs-csi-scc"}}                                         
{"level":"info","ts":1639782539.2153044,"logger":"cmd","msg":"No update needed."}                                                                                                   {"level":"info","ts":1639782539.2248325,"logger":"cmd","msg":"Found. Checking whether update is needed.","resource":{"namespace":"openshift-operators","name":"efs-csi-node"}}      
{"level":"info","ts":1639782539.2249322,"logger":"cmd","msg":"Update needed. Updating..."}                                                                                          {"level":"info","ts":1639782539.2336543,"logger":"cmd","msg":"Updated.","resource":{"namespace":"openshift-operators","name":"efs-csi-node"}}                                       
{"level":"info","ts":1639782539.2360437,"logger":"cmd","msg":"Creating.","resource":{"name":"efs.csi.aws.com"}}                                                                     
{"level":"info","ts":1639782539.2415602,"logger":"cmd","msg":"Created.","resource":{"name":"efs.csi.aws.com"}}                                                                      
{"level":"info","ts":1639782539.2441304,"logger":"cmd","msg":"Found. Checking whether update is needed.","resource":{"name":"efs-sc"}}                                              
{"level":"info","ts":1639782539.2441738,"logger":"cmd","msg":"No update needed."}                                                                                                   
I1217 23:09:01.995588       1 request.go:645] Throttling request took 2.74719813s, request: GET:https://172.30.0.1:443/apis/metal3.io/v1alpha1?timeout=32s                          
{"level":"info","ts":1639782544.768186,"logger":"metrics","msg":"Metrics Service object created","Service.Name":"aws-efs-operator-metrics","Service.Namespace":"openshift-operators"
}
{"level":"info","ts":1639782547.5327375,"logger":"cmd","msg":"Starting the Cmd."}
{"level":"info","ts":1639782547.5329247,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
{"level":"info","ts":1639782547.5329683,"logger":"controller","msg":"Starting EventSource","controller":"sharedvolume-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.5329897,"logger":"controller","msg":"Starting EventSource","controller":"statics-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.633707,"logger":"controller","msg":"Starting EventSource","controller":"sharedvolume-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.634364,"logger":"controller","msg":"Starting EventSource","controller":"statics-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.734494,"logger":"controller","msg":"Starting EventSource","controller":"sharedvolume-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.7346046,"logger":"controller","msg":"Starting EventSource","controller":"statics-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.8354259,"logger":"controller","msg":"Starting Controller","controller":"sharedvolume-controller"}
{"level":"info","ts":1639782547.8354814,"logger":"controller","msg":"Starting workers","controller":"sharedvolume-controller","worker count":1}
{"level":"info","ts":1639782547.8354268,"logger":"controller","msg":"Starting EventSource","controller":"statics-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782547.935819,"logger":"controller","msg":"Starting EventSource","controller":"statics-controller","source":"kind source: /, Kind="}
{"level":"info","ts":1639782548.03626,"logger":"controller","msg":"Starting Controller","controller":"statics-controller"}
{"level":"info","ts":1639782548.0363014,"logger":"controller","msg":"Starting workers","controller":"statics-controller","worker count":1}

```

Tested created a `SharedVolume` resource

```
oc get pvc -n james                                               
NAME      STATUS   VOLUME         CAPACITY   ACCESS MODES   STORAGECLASS   AGE
pvc-sv1   Bound    pv-james-sv1   1Gi        RWX            efs-sc         36s
```

