### PR TITLE
Prefer scheduling registry pod onto infra nodes

### DIFF
--- a/hack/olm-registry/olm-artifacts-template.yaml
+++ b/hack/olm-registry/olm-artifacts-template.yaml
@@ -21,6 +21,13 @@ objects:
     image: ${REGISTRY_IMG}:${CHANNEL}-${IMAGE_TAG}
     displayName: aws-efs-operator Registry
     publisher: SRE
+    grpcPodConfig:
+      nodeSelector:
+        node-role.kubernetes.io: infra
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/infra
+          operator: Exists
 
 - apiVersion: operators.coreos.com/v1alpha2
   kind: OperatorGroup


### PR DESCRIPTION
This commit specifies .spec.grpcPodConfig.nodeSelector and .spec.grpdPodConfig.tolerations to schedule this operator's registry pod to infra nodes when possible.

[OSD-6629](https://issues.redhat.com//browse/OSD-6629)